### PR TITLE
make tooltip more intuitive

### DIFF
--- a/app/components/rule-edit/template.hbs
+++ b/app/components/rule-edit/template.hbs
@@ -24,7 +24,7 @@
     groupValue=rule.action}}
     Ignore value
   {{/radio-button}}
-  <span data-toggle="tooltip"  data-placement="right"  title="Hides the value from reporting. Use for removing skills.">[ ? ]</span>
+  {{tool-tip title="Hides the value from reporting. Use for removing skills."}}
 </div>
 <div class="radio">
   {{#radio-button
@@ -32,5 +32,5 @@
     groupValue=rule.action}}
     Ignore job
   {{/radio-button}}
-  <span data-toggle="tooltip"  data-placement="right"  title=" Removes the job completely. Use for removing job titles.">[ ? ]</span>
+  {{tool-tip title="Removes the job completely. Use for removing job titles."}}
 </div>

--- a/app/components/tool-tip/component.js
+++ b/app/components/tool-tip/component.js
@@ -1,0 +1,13 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: 'span',
+  placement: 'right',
+  title: '',
+  didInsertElement() {
+    this.$().tooltip(this.getProperties('title', 'placement'));
+  },
+  willDestroyElement() {
+    this.$().tooltip('destroy');
+  }
+});

--- a/app/components/tool-tip/template.hbs
+++ b/app/components/tool-tip/template.hbs
@@ -1,0 +1,1 @@
+<span class="tooltip-hint glyphicon glyphicon-question-sign"></span>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -736,3 +736,7 @@ body.loading .content-wrapper {
 .term-edit{
   width: 100%;
 }
+
+.tooltip-hint:hover {
+  cursor: pointer;
+}

--- a/tests/integration/components/tool-tip/component-test.js
+++ b/tests/integration/components/tool-tip/component-test.js
@@ -1,0 +1,26 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('tool-tip', 'Integration | Component | tool tip', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{tool-tip}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#tool-tip}}
+      template block text
+    {{/tool-tip}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
resolve #54
@johnnyoshika I have decided to make this tool-tip more like the tool-tip in jobcast.
https://github.com/bcjobs/jobcast-dashboard/tree/master/app/pods/components/tool-tip
