### PR TITLE
Replace Avg. age

### DIFF
--- a/app/components/bcic-subreport/template.hbs
+++ b/app/components/bcic-subreport/template.hbs
@@ -64,7 +64,7 @@
               </div>
               <div class="col-xs-4">
                 <div class="clearfix">
-                  <strong>Avg. Age</strong>
+                  <strong>Avg. Days</strong>
                 </div>
                 {{format-number data.summary.averageAge}}
               </div>

--- a/app/components/trend-table/template.hbs
+++ b/app/components/trend-table/template.hbs
@@ -6,7 +6,7 @@
             {{#unless isCompany}}
                 <th>Companies</th>
             {{/unless}}
-            <th>Avg. Age</th>
+            <th>Avg. Days</th>
         </tr>
         {{#each visibleItems as |trend|}}
             <tr>


### PR DESCRIPTION
I used `Avg. Days` instead of `Ave. Days`. I assume that's appropriate?
Closes #75
