### PR TITLE
Collapse terms ui to make it cleaner

### DIFF
--- a/app/components/rule-row/component.js
+++ b/app/components/rule-row/component.js
@@ -1,12 +1,15 @@
 import Ember from 'ember';
 
+let expandText = "Expand...";
+let collapseText = "Collapse...";
+
 export default Ember.Component.extend({
   tagName: 'tr',
 
   terms: Ember.computed('rule.terms', function() {
     return this.get('rule.terms');
   }),
-
+  toggleText: expandText,
   description: Ember.computed('rule.action', 'rule.replaceWith', function() {
     var {action, replaceWith} = this.get('rule');
     switch (action) {
@@ -22,6 +25,10 @@ export default Ember.Component.extend({
   actions: {
     delete() {
       this.sendAction('delete', this.get('rule'));
+    },
+    toggleTerm() {
+      $(`[data-rule="${this.get('rule.id')}"]`).toggle();
+      $(`[data-rule="${this.get('rule.id')}"]`).is(":visible") ? this.set('toggleText', collapseText) : this.set('toggleText', expandText);
     }
   }
 });

--- a/app/components/rule-row/component.js
+++ b/app/components/rule-row/component.js
@@ -27,8 +27,12 @@ export default Ember.Component.extend({
       this.sendAction('delete', this.get('rule'));
     },
     toggleTerm() {
-      $(`[data-rule="${this.get('rule.id')}"]`).toggle();
-      $(`[data-rule="${this.get('rule.id')}"]`).is(":visible") ? this.set('toggleText', collapseText) : this.set('toggleText', expandText);
+      this.$(`[data-rule="${this.get('rule.id')}"]`).toggle();
+      if(this.$(`[data-rule="${this.get('rule.id')}"]`).is(":visible")){
+        this.set('toggleText', collapseText);
+      } else {
+        this.set('toggleText', expandText);
+      }
     }
   }
 });

--- a/app/components/rule-row/template.hbs
+++ b/app/components/rule-row/template.hbs
@@ -1,7 +1,10 @@
 <td>
-  {{#each terms as |term|}}
-    {{term}} <br />
-  {{/each}}
+  <span data-rule="{{rule.id}}" style="display:none">
+    {{#each terms as |term|}}
+      {{term}} <br />
+    {{/each}}
+  </span>
+  <a href="" {{action "toggleTerm"}}>{{toggleText}}</a>
 </td>
 <td>
   {{description}}


### PR DESCRIPTION
Related to bcjobs/analytics#154
@johnnyoshika When the ui is collapsed it has a different column width, is that fine or should we set custom widths so it is always the same?

All collapsed
![image](https://cloud.githubusercontent.com/assets/6888104/14757455/7bfc7934-08a8-11e6-8784-c6ab3c2b0359.png)

Expanded
![image](https://cloud.githubusercontent.com/assets/6888104/14757460/896c88c0-08a8-11e6-93c4-c4ca2ed89e4e.png)

CC: @JasmineBCjobs
