### PR TITLE
Trends report ui

### DIFF
--- a/app/components/bcic-report/template.hbs
+++ b/app/components/bcic-report/template.hbs
@@ -86,7 +86,7 @@
                         <h3>Trending Job Titles</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.titles.byOpenJobs type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.titles.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -96,7 +96,7 @@
                         <h3>Top Job Titles</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.titles.byAllJobs type=type atDate=atDate exportSet="trendingNewJobTitles" trendType="Title" displayPrevious=false}}
+                        {{#trend-table model=model.tables.trends.titles.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobTitles" trendType="Title" displayPrevious=false}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -108,7 +108,7 @@
                         <h3>Trending Skills</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.skills.byOpenJobs type=type atDate=atDate exportSet="trendingOpenJobSkills" trendType="Skill"}}
+                        {{#trend-table model=model.tables.trends.skills.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobSkills" trendType="Skill"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -118,7 +118,117 @@
                         <h3>Top Skills</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.skills.byAllJobs type=type atDate=atDate exportSet="trendingNewJobSkills" trendType="Skill" displayPrevious=false}}
+                        {{#trend-table model=model.tables.trends.skills.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobSkills" trendType="Skill" displayPrevious=false}}
+                            By <strong>all</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+            </div>
+            <div class="row clearfix">
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Degrees</h3>
+                        <h4>Daily</h4>
+
+                        {{#trend-table model=model.tables.trends.educations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>open</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Degrees</h3>
+                        <h4>All Time</h4>
+
+                        {{#trend-table model=model.tables.trends.educations.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>all</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+            </div>
+            <div class="row clearfix">
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Experience Levels</h3>
+                        <h4>Daily</h4>
+
+                        {{#trend-table model=model.tables.trends.experiences.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>open</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Experience Levels</h3>
+                        <h4>All Time</h4>
+
+                        {{#trend-table model=model.tables.trends.experiences.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>all</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+            </div>
+            <div class="row clearfix">
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Job Types</h3>
+                        <h4>Daily</h4>
+
+                        {{#trend-table model=model.tables.trends.jobTypes.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>open</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Job Types</h3>
+                        <h4>All Time</h4>
+
+                        {{#trend-table model=model.tables.trends.jobTypes.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>all</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+            </div>
+            <div class="row clearfix">
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Regions</h3>
+                        <h4>Daily</h4>
+
+                        {{#trend-table model=model.tables.trends.regions.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>open</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Regions</h3>
+                        <h4>All Time</h4>
+
+                        {{#trend-table model=model.tables.trends.regions.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>all</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+            </div>
+            <div class="row clearfix">
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Associations</h3>
+                        <h4>Daily</h4>
+
+                        {{#trend-table model=model.tables.trends.associations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                            By <strong>open</strong> jobs
+                        {{/trend-table}}
+                    </div>
+                </div>
+                <div class="col global-translucent">
+                    <div class="card-wrapper global-shadow">
+                        <h3>Associations</h3>
+                        <h4>All Time</h4>
+
+                        {{#trend-table model=model.tables.trends.associations.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -160,8 +270,6 @@
                     </div>
                 </div>
             </div>
-
-
         </div>
     </div>
     <div class="footer">

--- a/app/components/bcic-report/template.hbs
+++ b/app/components/bcic-report/template.hbs
@@ -130,7 +130,7 @@
                         <h3>Degrees</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.educations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.educations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobDegrees" trendType="Degree"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -140,7 +140,7 @@
                         <h3>Degrees</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.educations.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.educations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobDegrees" trendType="Degree"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -152,7 +152,7 @@
                         <h3>Experience Levels</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.experiences.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.experiences.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobExperience" trendType="Experience"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -162,7 +162,7 @@
                         <h3>Experience Levels</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.experiences.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.experiences.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobExperience" trendType="Experience"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -174,7 +174,7 @@
                         <h3>Job Types</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.jobTypes.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.jobTypes.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTypes" trendType="JobType"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -184,7 +184,7 @@
                         <h3>Job Types</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.jobTypes.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.jobTypes.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobTypes" trendType="JobType"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -196,7 +196,7 @@
                         <h3>Regions</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.regions.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.regions.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobRegions" trendType="Region"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -206,7 +206,7 @@
                         <h3>Regions</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.regions.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.regions.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobRegions" trendType="Region"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -218,7 +218,7 @@
                         <h3>Associations</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.associations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.associations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobAssociations" trendType="Association"}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -228,7 +228,7 @@
                         <h3>Associations</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.associations.byAllJobs.data type=type atDate=atDate exportSet="trendingOpenJobTitles" trendType="Title"}}
+                        {{#trend-table model=model.tables.trends.associations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobAssociations" trendType="Association"}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>

--- a/app/components/bcic-report/template.hbs
+++ b/app/components/bcic-report/template.hbs
@@ -127,20 +127,20 @@
             <div class="row clearfix">
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Degrees</h3>
+                        <h3>Education</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.educations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobDegrees" trendType="Degree"}}
+                        {{#trend-table model=model.tables.trends.educations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobDegrees" trendType="Degree" coverageDisplayName="degrees" coverage=model.tables.trends.educations.byOpenJobs.coverage}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
                 </div>
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Degrees</h3>
+                        <h3>Education</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.educations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobDegrees" trendType="Degree"}}
+                        {{#trend-table model=model.tables.trends.educations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobDegrees" trendType="Degree" coverageDisplayName="degrees" coverage=model.tables.trends.educations.byAllJobs.coverage}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -149,20 +149,20 @@
             <div class="row clearfix">
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Experience Levels</h3>
+                        <h3>Experience</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.experiences.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobExperience" trendType="Experience"}}
+                        {{#trend-table model=model.tables.trends.experiences.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobExperience" trendType="Experience" coverageDisplayName="experience levels" coverage=model.tables.trends.experiences.byOpenJobs.coverage}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
                 </div>
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Experience Levels</h3>
+                        <h3>Experience</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.experiences.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobExperience" trendType="Experience"}}
+                        {{#trend-table model=model.tables.trends.experiences.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobExperience" trendType="Experience" coverageDisplayName="experience levels" coverage=model.tables.trends.experiences.byAllJobs.coverage}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -171,20 +171,20 @@
             <div class="row clearfix">
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Job Types</h3>
+                        <h3>Job Type</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.jobTypes.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTypes" trendType="JobType"}}
+                        {{#trend-table model=model.tables.trends.jobTypes.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobTypes" trendType="JobType" coverageDisplayName="job types" coverage=model.tables.trends.jobTypes.byOpenJobs.coverage}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
                 </div>
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Job Types</h3>
+                        <h3>Job Type</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.jobTypes.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobTypes" trendType="JobType"}}
+                        {{#trend-table model=model.tables.trends.jobTypes.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobTypes" trendType="JobType" coverageDisplayName="job types" coverage=model.tables.trends.jobTypes.byAllJobs.coverage}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -193,20 +193,20 @@
             <div class="row clearfix">
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Regions</h3>
+                        <h3>Region</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.regions.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobRegions" trendType="Region"}}
+                        {{#trend-table model=model.tables.trends.regions.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobRegions" trendType="Region" coverageDisplayName="regions" coverage=model.tables.trends.regions.byOpenJobs.coverage}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
                 </div>
                 <div class="col global-translucent">
                     <div class="card-wrapper global-shadow">
-                        <h3>Regions</h3>
+                        <h3>Region</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.regions.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobRegions" trendType="Region"}}
+                        {{#trend-table model=model.tables.trends.regions.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobRegions" trendType="Region" coverageDisplayName="regions" coverage=model.tables.trends.regions.byAllJobs.coverage}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -218,7 +218,7 @@
                         <h3>Associations</h3>
                         <h4>Daily</h4>
 
-                        {{#trend-table model=model.tables.trends.associations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobAssociations" trendType="Association"}}
+                        {{#trend-table model=model.tables.trends.associations.byOpenJobs.data type=type atDate=atDate exportSet="trendingOpenJobAssociations" trendType="Association" coverageDisplayName="associations" coverage=model.tables.trends.associations.byOpenJobs.coverage}}
                             By <strong>open</strong> jobs
                         {{/trend-table}}
                     </div>
@@ -228,7 +228,7 @@
                         <h3>Associations</h3>
                         <h4>All Time</h4>
 
-                        {{#trend-table model=model.tables.trends.associations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobAssociations" trendType="Association"}}
+                        {{#trend-table model=model.tables.trends.associations.byAllJobs.data type=type atDate=atDate exportSet="trendingNewJobAssociations" trendType="Association" coverageDisplayName="associations" coverage=model.tables.trends.associations.byAllJobs.coverage}}
                             By <strong>all</strong> jobs
                         {{/trend-table}}
                     </div>

--- a/app/components/bcic-subreport/component.js
+++ b/app/components/bcic-subreport/component.js
@@ -9,22 +9,18 @@ export default Ember.Component.extend({
   }),
   data: Ember.computed('model', 'model.[]', function(){
     var data = this.get('model');
-    // Decides what charts to show depending on trend
-    if(this.get('trend') === 'Company'){
-      this.set('isCompany', true);
-      data.skillChart = data.skills;
-      data.titleChart = data.titles;
-    } else if(this.get('trend') === 'Title') {
-      data.skillChart = data.skills;
-      data.companyChart = {
-        top: data.companies
-      };
-    } else if(this.get('trend') === 'Skill'){
-      data.titleChart = data.titles;
-      data.companyChart = {
-        top: data.companies
-      };
-    }
+    data.skillChart = data.skills;
+    data.titleChart = data.titles;
+    data.companyChart = {
+      top: data.companies
+    };
+
+    // Hide company column when looking at a specific company
+    this.set('isCompany', this.get('trend') === 'Company');
+
+    // Remove chart that isn't relevent to current trend
+    data[`${this.get('trend').toLowerCase()}Chart`] = null;
+
     return data;
   }),
   startsAt: Ember.computed('range', function() {

--- a/app/components/trend-table/component.js
+++ b/app/components/trend-table/component.js
@@ -6,7 +6,9 @@ var DATE_FORMAT = 'YYYY-MM-DD';
 
 export default Ember.Component.extend(ShowMore, {
   items: Ember.computed.alias('model'),
-
+  percent: Ember.computed('coverage', function(){
+    return this.get('coverage') * 100;
+  }),
   displayPrevious: true,
 
   displayDownload: Ember.computed('exportSet', 'session.isAdmin', function(){

--- a/app/components/trend-table/template.hbs
+++ b/app/components/trend-table/template.hbs
@@ -48,7 +48,7 @@
     {{#if coverage}}
         <div class="table-showmore-wrapper">
             <span class="table-showmore-finished">
-                These {{coverageDisplayName}} represent {{format-number percent}}% of Y total openings.
+                These {{coverageDisplayName}} represent {{format-number percent}}% of total openings.
             </span>
         </div>
     {{else}}

--- a/app/components/trend-table/template.hbs
+++ b/app/components/trend-table/template.hbs
@@ -45,11 +45,19 @@
         </div>
     </div>
 {{else}}
-    <div class="table-showmore-wrapper">
-        <span class="table-showmore-finished">
-            Showing {{items.length}} results.
-        </span>
-    </div>
+    {{#if coverage}}
+        <div class="table-showmore-wrapper">
+            <span class="table-showmore-finished">
+                These {{coverageDisplayName}} represent {{format-number percent}}% of Y total openings.
+            </span>
+        </div>
+    {{else}}
+        <div class="table-showmore-wrapper">
+            <span class="table-showmore-finished">
+                Showing {{items.length}} results.
+            </span>
+        </div>
+    {{/if}}
     {{#if displayDownload}}
       <div class="table-showmore-wrapper" {{action "downloadCSV"}}>
           Download all records


### PR DESCRIPTION
Closes #85 
@johnnyoshika In this issue I noticed all tables said `By open jobs`, I am assuming that was a copy paste error and the all time tables should say `By all jobs`.  If not I can change them all to `By open jobs`.
