### PR TITLE
Adjust padding and horiz scroll

### DIFF
--- a/app/components/page-header/template.hbs
+++ b/app/components/page-header/template.hbs
@@ -6,7 +6,7 @@
 </div>
 <div class="title-wrapper">
   <div class="title global-fullwidth clearfix">
-    <div class="row">
+    <div class="xs-mb15">
       <div class="xs-nofloat">
         <div class="clearfix">
           {{#unless hideDatepicker}}
@@ -26,10 +26,10 @@
       </div>
     </div>
     <div class="clearfix title-overview">
-      <div class="pull-left">
+      <div class="col-xs-6 text-left">
         <a href="#" {{action "switchReport" type}}>{{switchReportName}}</a>
       </div>
-      <div class="pull-right">
+      <div class="col-xs-6 text-right">
         {{#if session.user}}
           {{session.user.firstName}} | <a href="#" {{action "logout"}}>Logout</a>
         {{else}}


### PR DESCRIPTION
Fixes #90

Note: `.row` class needs to be used more carefully. It has negative margins, and was causing the horizontal scroll.
