### PR TITLE
Filter out empty datapoints

### DIFF
--- a/app/components/bar-chart/component.js
+++ b/app/components/bar-chart/component.js
@@ -6,7 +6,8 @@ import numeral from 'npm:numeral';
 
 export default Ember.Component.extend({
   data: Ember.computed('model', function() {
-    var model = this.get('model');
+    // Filter out empty data points
+    var model = this.get('model').filter(item => { if(item.y !== 0.0) return item});
     return {
       labels: model.map(item => moment(item.x).format('MMM')),
       series: [


### PR DESCRIPTION
The reason the chart was displaying empty data is because the trends API was returning empty data points.  This PR will filter out the empty data points on the client side, but I have also created an issue so we can remove them server side.

Related server side issue:  https://github.com/bcjobs/analytics/issues/337

Closes #101