### PR TITLE
Tooltip fix

### DIFF
--- a/app/components/bar-chart/component.js
+++ b/app/components/bar-chart/component.js
@@ -7,7 +7,7 @@ import numeral from 'npm:numeral';
 export default Ember.Component.extend({
   data: Ember.computed('model', function() {
     // Filter out empty data points
-    var model = this.get('model').filter(item => { if(item.y !== 0.0) return item});
+    var model = this.get('model').filter(item => { if(item.y !== 0.0) { return item; } });
     return {
       labels: model.map(item => moment(item.x).format('MMM')),
       series: [
@@ -30,7 +30,7 @@ export default Ember.Component.extend({
 
   draw(data) {
     if (data.type === 'bar') {
-      var datum = this.get('model')[data.index];
+      var datum = this.get('model').filter(item => { if(item.y !== 0.0) { return item; } })[data.index];
 
       var $bar = $(data.element._node);
 

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "qunit": "~1.18.0",
     "chartist": "~0.9.4",
     "bootstrap-datepicker": "~1.4.1",
-    "bootstrap": "~3.3.2",
+    "bootstrap": "3.3.6",
     "typeahead.js": "~0.11.1",
     "ember-uploader": "0.3.11",
     "select2": "3.5.2"


### PR DESCRIPTION
Closes #103 

The tooltips were in the wrong location because of a bug in the latest version of Bootstrap (v3.3.7) that got deployed when we added Application Insights.
Because of this bug we will have to use Bootstrap v3.3.6 and below until Bootstrap v4 is released, as Bootstrap 3 is no longer being developed/supported.

Bootstrap scroll issue: https://github.com/twbs/bootstrap/issues/20381
Bootstrap 3 no longer being developed: https://github.com/twbs/bootstrap/issues/20631
