### PR TITLE
Load Roboto font over https

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,7 @@
 
     {{content-for 'head'}}
 
-    <link href='http://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:400,300,700' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/analytics-dashboard.css">
 


### PR DESCRIPTION
Prevents mixed content errors.

![image](https://cloud.githubusercontent.com/assets/6888104/21434937/c4b34516-c82b-11e6-9272-33e7fa3a7059.png)
